### PR TITLE
add a cow implementation for blob storage

### DIFF
--- a/agentcow/__init__.py
+++ b/agentcow/__init__.py
@@ -5,3 +5,5 @@ __version__ = "0.1.3"
 from .context import CowConfig
 
 __all__ = ["CowConfig"]
+
+# blob subpackage available via `from agentcow.blob import ...`

--- a/agentcow/blob/README.md
+++ b/agentcow/blob/README.md
@@ -84,14 +84,17 @@ After the session, inspect what the agent did and selectively commit or discard:
 ```python
 from agentcow.blob import (
     get_blob_session_operations,
+    get_blob_session_records,
     get_blob_dependencies,
     commit_cow_blobs,
     discard_cow_blobs,
 )
 
 ops = get_blob_session_operations(backend, bucket, prefix, ".cow", session_id)
+records = get_blob_session_records(backend, bucket, prefix, ".cow", session_id)
 deps = get_blob_dependencies(backend, bucket, prefix, ".cow", session_id)
 # ops:  [UUID('aaa...'), UUID('bbb...'), UUID('ccc...')]
+# records: [CowBlobRecord(final_path='org/file.txt', ...), ...]
 # deps: [(UUID('aaa...'), UUID('bbb...')), ...]  — bbb depends on aaa
 
 # Cherry-pick: commit the good operations, discard the rest
@@ -149,6 +152,7 @@ When two operations touch the same file, a dependency edge `(earlier_op, later_o
 | Function | Description |
 |----------|-------------|
 | `get_blob_session_operations(backend, bucket, prefix, ns, session_id)` | List all uncommitted blob operation UUIDs for a session |
+| `get_blob_session_records(backend, bucket, prefix, ns, session_id, operation_ids=None)` | Return `CowBlobRecord` entries for the session, optionally scoped to specific operations |
 | `get_blob_dependencies(backend, bucket, prefix, ns, session_id)` | Get `(depends_on, operation_id)` pairs for blob operations in a session |
 | `get_blob_operation_diff(backend, bucket, prefix, ns, session_id, operation_id)` | Compute before/after content diff for a single operation |
 

--- a/agentcow/blob/README.md
+++ b/agentcow/blob/README.md
@@ -1,0 +1,168 @@
+# agent-cow — Blob Storage
+
+S3 blob storage backend for [agent-cow](../../README.md). Provides Copy-On-Write interception for S3 operations via boto3 event hooks — writes go to scratch paths, reads resolve through session history, deletes write tombstones instead of removing data.
+
+## Installation
+
+```bash
+pip install agent-cow
+```
+
+Requires Python 3.10+ and a boto3-compatible S3 client.
+
+## Quick Start
+
+### 1. Create the interceptor
+
+`agent-cow` intercepts your existing boto3 S3 client by registering event hooks. A `ContextVar` carries the active session's COW configuration — when it's set, the hooks redirect S3 operations to scratch paths:
+
+```python
+from contextvars import ContextVar
+from agentcow.blob import CowBlobInterceptor, CowBlobConfig
+
+cow_blob_ctx: ContextVar[CowBlobConfig | None] = ContextVar("cow_blob_ctx", default=None)
+
+s3_client = boto3.client("s3")
+interceptor = CowBlobInterceptor(s3_client, cow_blob_ctx)
+```
+
+The interceptor registers `before-parameter-build` event hooks on the S3 client for `PutObject`, `CreateMultipartUpload`, `GetObject`, and `HeadObject`. When the context var is `None`, the hooks are no-ops.
+
+### 2. Start a COW session
+
+Set the context var before your agent runs S3 operations. Each discrete action gets its own `operation_id`:
+
+```python
+import uuid
+from agentcow.blob import CowBlobConfig
+
+session_id = uuid.uuid4()
+
+config = CowBlobConfig(
+    session_id=session_id,
+    operation_id=uuid.uuid4(),
+    path_prefix="my-org/",
+)
+cow_blob_ctx.set(config)
+
+# Agent uploads a file — transparently redirected to scratch path:
+#   my-org/documents/report.pdf -> my-org/.cow/session_{sid}/blobs/{op_id}/documents/report.pdf
+s3_client.put_object(Bucket="my-bucket", Key="my-org/documents/report.pdf", Body=data)
+
+# For the next action, rotate the operation_id
+config.operation_id = uuid.uuid4()
+
+# Agent reads a file — resolves through session history,
+# returning the scratch version if one exists
+s3_client.get_object(Bucket="my-bucket", Key="my-org/documents/report.pdf")
+```
+
+Production data is untouched. Other sessions see only the original objects.
+
+### 3. Handle deletes
+
+Deletes use a decorator on your storage backend's `delete_file` method rather than boto3 event hooks:
+
+```python
+from agentcow.blob import cow_intercept_delete
+
+class MyStorageBackend:
+    def __init__(self, s3_client, interceptor):
+        self.cow_interceptor = interceptor
+
+    @cow_intercept_delete
+    def delete_file(self, bucket_name, object_name):
+        self._s3_client.delete_object(Bucket=bucket_name, Key=object_name)
+```
+
+When intercepted, the decorator writes a zero-byte tombstone to `tombstones/{op_id}/{relative_path}` and skips the real delete. Subsequent reads of the deleted path raise `FileNotFoundError`.
+
+### 4. Review and commit
+
+After the session, inspect what the agent did and selectively commit or discard:
+
+```python
+from agentcow.blob import (
+    get_blob_session_operations,
+    get_blob_dependencies,
+    commit_cow_blobs,
+    discard_cow_blobs,
+)
+
+ops = get_blob_session_operations(backend, bucket, prefix, ".cow", session_id)
+deps = get_blob_dependencies(backend, bucket, prefix, ".cow", session_id)
+# ops:  [UUID('aaa...'), UUID('bbb...'), UUID('ccc...')]
+# deps: [(UUID('aaa...'), UUID('bbb...')), ...]  — bbb depends on aaa
+
+# Cherry-pick: commit the good operations, discard the rest
+commit_cow_blobs(backend, bucket, prefix, ".cow", session_id, operation_ids=[ops[0]])
+discard_cow_blobs(backend, bucket, prefix, ".cow", session_id, operation_ids=[ops[1], ops[2]])
+
+# Or commit everything at once
+commit_cow_blobs(backend, bucket, prefix, ".cow", session_id)
+```
+
+## How It Works
+
+1. **Registers boto3 event hooks** on the singleton S3 client for write and read operations
+2. **Redirects writes** to operation-scoped scratch paths under a `.cow` namespace
+3. **Resolves reads** through file history, returning the latest scratch version or falling back to production
+4. **Records deletes** as zero-byte tombstone objects instead of actually removing anything
+5. **Your code doesn't change** — S3 calls still use production keys; the interceptor rewrites them transparently
+
+All scratch data lives under a `.cow` namespace within the org's prefix:
+
+```
+{org_id}/.cow/session_{session_id}/blobs/{operation_id}/{relative_path}       # writes
+{org_id}/.cow/session_{session_id}/tombstones/{operation_id}/{relative_path}  # deletes
+```
+
+The key structure stores information about the operation — `blobs/` means write, `tombstones/` means delete, and `LastModified` provides chronological ordering.
+
+### Bypassing interception
+
+`bypass_cow()` is a context manager that temporarily sets the context var to `None`. Use it when you need to read the production version of a file while a session is active (e.g. computing diffs):
+
+```python
+from agentcow.blob import bypass_cow
+
+with bypass_cow(cow_blob_ctx):
+    original = s3_client.get_object(Bucket="my-bucket", Key="my-org/documents/report.pdf")
+```
+
+### Dependencies
+
+When two operations touch the same file, a dependency edge `(earlier_op, later_op)` is recorded. At query time, `get_blob_dependencies()` rebuilds these edges from S3 keys by grouping records by path and sorting by timestamp.
+
+## API Reference
+
+### Interception
+
+| Function / Class | Description |
+|------------------|-------------|
+| `CowBlobInterceptor(s3_client, context_var)` | Registers boto3 event hooks for transparent COW path interception on the given S3 client |
+| `bypass_cow(context_var)` | Context manager that temporarily disables COW interception for direct production access |
+| `cow_intercept_delete` | Decorator that redirects deletes to tombstone writes when a COW session is active |
+
+### Review
+
+| Function | Description |
+|----------|-------------|
+| `get_blob_session_operations(backend, bucket, prefix, ns, session_id)` | List all uncommitted blob operation UUIDs for a session |
+| `get_blob_dependencies(backend, bucket, prefix, ns, session_id)` | Get `(depends_on, operation_id)` pairs for blob operations in a session |
+| `get_blob_operation_diff(backend, bucket, prefix, ns, session_id, operation_id)` | Compute before/after content diff for a single operation |
+
+### Commit / Discard
+
+| Function | Description |
+|----------|-------------|
+| `commit_cow_blobs(backend, bucket, prefix, ns, session_id, operation_ids=None)` | Commit COW blobs: copy writes to production, apply deletes, clean up scratch. Returns record count |
+| `discard_cow_blobs(backend, bucket, prefix, ns, session_id, operation_ids=None)` | Discard COW blobs: delete scratch paths and tombstones without touching production. Returns record count |
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `CowBlobConfig` | Dataclass with `session_id`, `operation_id`, `path_prefix`, `scratch_namespace`, `pending_writes`, `dependencies`, `file_history` fields |
+| `CowBlobRecord` | Dataclass representing a single pending blob write or delete: `final_path`, `is_delete`, `timestamp`, `bucket_name`, `cow_path`, `operation_id` |
+| `BlobOperationDiff` | Dataclass with `before_content`, `after_content`, `is_new_file`, `is_delete` fields |

--- a/agentcow/blob/__init__.py
+++ b/agentcow/blob/__init__.py
@@ -1,0 +1,29 @@
+"""Copy-On-Write blob storage implementation."""
+
+from .interceptor import CowBlobInterceptor, bypass_cow, cow_intercept_delete
+from .operations import (
+    commit_cow_blobs,
+    discard_cow_blobs,
+    get_blob_dependencies,
+    get_blob_operation_diff,
+    get_blob_session_operations,
+)
+from .context import (
+    BlobOperationDiff,
+    CowBlobConfig,
+    CowBlobRecord,
+)
+
+__all__ = [
+    "CowBlobInterceptor",
+    "bypass_cow",
+    "cow_intercept_delete",
+    "commit_cow_blobs",
+    "discard_cow_blobs",
+    "get_blob_dependencies",
+    "get_blob_operation_diff",
+    "get_blob_session_operations",
+    "BlobOperationDiff",
+    "CowBlobConfig",
+    "CowBlobRecord",
+]

--- a/agentcow/blob/__init__.py
+++ b/agentcow/blob/__init__.py
@@ -7,6 +7,7 @@ from .operations import (
     get_blob_dependencies,
     get_blob_operation_diff,
     get_blob_session_operations,
+    get_blob_session_records,
 )
 from .context import (
     BlobOperationDiff,
@@ -23,6 +24,7 @@ __all__ = [
     "get_blob_dependencies",
     "get_blob_operation_diff",
     "get_blob_session_operations",
+    "get_blob_session_records",
     "BlobOperationDiff",
     "CowBlobConfig",
     "CowBlobRecord",

--- a/agentcow/blob/context.py
+++ b/agentcow/blob/context.py
@@ -22,7 +22,6 @@ class CowBlobRecord:
     bucket_name: str = ""
     cow_path: str = ""
     operation_id: uuid.UUID | None = None
-    group_key: str | None = None
 
 
 @dataclass
@@ -46,7 +45,6 @@ class CowBlobConfig(CowConfig):
 
     path_prefix: str = ""
     scratch_namespace: str = ".cow"
-    group_key: str | None = None
     pending_writes: list[CowBlobRecord] = field(default_factory=list)
     dependencies: list[tuple[uuid.UUID, uuid.UUID]] = field(default_factory=list)
     file_history: dict[str, list[tuple[uuid.UUID, bool, str]]] = field(

--- a/agentcow/blob/context.py
+++ b/agentcow/blob/context.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+from agentcow.context import CowConfig
+
+
+@dataclass
+class CowBlobRecord:
+    """A single pending blob write or delete.
+
+    Only ``final_path``, ``is_delete``, and ``timestamp`` are serialized
+    to the manifest.  The remaining fields are populated at runtime from
+    context that is already available (bucket from the caller, operation_id
+    from the manifest filename, cow_path from path conventions).
+    """
+
+    final_path: str
+    is_delete: bool = False
+    timestamp: str = ""
+    bucket_name: str = ""
+    cow_path: str = ""
+    operation_id: uuid.UUID | None = None
+    group_key: str | None = None
+
+
+@dataclass
+class BlobOperationDiff:
+    """Before/after content for a single operation on a single file."""
+
+    before_content: str | None
+    after_content: str | None
+    is_new_file: bool
+    is_delete: bool
+
+
+@dataclass
+class CowBlobConfig(CowConfig):
+    """Configuration and runtime state for a COW blob session.
+
+    Parallel to agentcow's CowRequestConfig. The blob interceptor reads
+    and writes these fields during interception. Applications can
+    subclass to add backend-specific fields (e.g. visible_operations).
+    """
+
+    path_prefix: str = ""
+    scratch_namespace: str = ".cow"
+    group_key: str | None = None
+    pending_writes: list[CowBlobRecord] = field(default_factory=list)
+    dependencies: list[tuple[uuid.UUID, uuid.UUID]] = field(default_factory=list)
+    file_history: dict[str, list[tuple[uuid.UUID, bool, str]]] = field(
+        default_factory=dict
+    )
+    history_loaded: bool = False

--- a/agentcow/blob/interceptor.py
+++ b/agentcow/blob/interceptor.py
@@ -19,12 +19,20 @@ import uuid
 from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 from .context import CowBlobConfig, CowBlobRecord
 from .paths import cow_session_prefix, parse_cow_key, to_cow_path, to_tombstone_path
 
 logger = logging.getLogger(__name__)
+
+
+class ListedCowEntry(NamedTuple):
+    final_path: str
+    op_id: uuid.UUID
+    is_delete: bool
+    last_modified: datetime
+    s3_key: str
 
 
 @contextmanager
@@ -192,19 +200,29 @@ class CowBlobInterceptor:
         )
         paginator = self._s3_client.get_paginator("list_objects_v2")
 
-        entries: list[tuple[str, uuid.UUID, bool, datetime]] = []
+        entries: list[ListedCowEntry] = []
         for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
             for obj in page.get("Contents", []):
                 parsed = parse_cow_key(obj["Key"], prefix, ctx.path_prefix)
                 if parsed is None:
                     continue
                 op_id, final_path, is_delete = parsed
-                entries.append((final_path, op_id, is_delete, obj["LastModified"]))
+                entries.append(
+                    ListedCowEntry(
+                        final_path=final_path,
+                        op_id=op_id,
+                        is_delete=is_delete,
+                        last_modified=obj["LastModified"],
+                        s3_key=obj["Key"],
+                    )
+                )
 
-        entries.sort(key=lambda e: e[3])
+        entries.sort(key=lambda e: (e.last_modified, e.s3_key))
 
-        for final_path, op_id, is_delete, _ in entries:
-            ctx.file_history.setdefault(final_path, []).append((op_id, is_delete))
+        for entry in entries:
+            ctx.file_history.setdefault(entry.final_path, []).append(
+                (entry.op_id, entry.is_delete)
+            )
 
     def _resolve_read_path(self, ctx: CowBlobConfig, object_name: str) -> Optional[str]:
         """Return the path to read from, or None if deleted in this session."""

--- a/agentcow/blob/interceptor.py
+++ b/agentcow/blob/interceptor.py
@@ -1,0 +1,272 @@
+"""
+boto3 event hooks for transparent COW blob path interception.
+
+Registers on the S3 client's event system to rewrite Keys when a COW
+session is active (context var is set).  Reads resolve through file
+history; writes redirect to operation-scoped scratch paths; deletes
+write zero-byte tombstone blobs.
+
+The interceptor is fully self-contained — it uses the S3 client directly
+for tombstone writes and session listing, with no dependency on
+higher-level storage abstractions.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from .context import CowBlobConfig, CowBlobRecord
+from .paths import cow_session_prefix, parse_cow_key, to_cow_path, to_tombstone_path
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def bypass_cow(context_var: ContextVar[Any]):
+    """Temporarily disable COW interception for the current context.
+
+    Use this when you need to read/write production paths directly
+    while a COW session is active (e.g. reading original content for diffs).
+    """
+    token = context_var.set(None)
+    try:
+        yield
+    finally:
+        context_var.reset(token)
+
+
+def cow_intercept_delete(fn):
+    """Decorator that suppresses the wrapped delete when a COW session is active.
+
+    Expects the decorated method's ``self`` to have a ``cow_interceptor``
+    attribute (a ``CowBlobInterceptor`` instance).  The first two positional
+    args after ``self`` must be ``bucket_name`` and ``object_name``.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(self, bucket_name, object_name, *args, **kwargs):
+        if self.cow_interceptor.record_delete(bucket_name, object_name):
+            return
+        return fn(self, bucket_name, object_name, *args, **kwargs)
+
+    return wrapper
+
+
+_WRITE_OPS = ("PutObject", "CreateMultipartUpload")
+_READ_OPS = ("GetObject", "HeadObject")
+
+
+class CowBlobInterceptor:
+    """Registers boto3 event hooks for transparent COW path interception.
+
+    When the context var holds an active COW session, write operations
+    have their Key rewritten to a scratch path, read operations resolve
+    through the session's file history, and deletes write zero-byte
+    tombstone blobs instead of actually deleting.
+
+    The interceptor is registered once on the singleton S3 client and
+    checks the context var on every call — when no COW session is active,
+    the hooks are no-ops.
+
+    File history is derived from S3 key structure (blobs/ and tombstones/
+    subdirectories under the session prefix) rather than separate manifest
+    files.
+    """
+
+    def __init__(
+        self,
+        s3_client,
+        context_var: ContextVar[Any],
+    ):
+        self._s3_client = s3_client
+        self._context_var: ContextVar[Optional[CowBlobConfig]] = context_var
+
+        for op in _WRITE_OPS:
+            s3_client.meta.events.register(
+                f"before-parameter-build.s3.{op}", self._intercept_write
+            )
+        for op in _READ_OPS:
+            s3_client.meta.events.register(
+                f"before-parameter-build.s3.{op}", self._intercept_read
+            )
+
+    def _get_ctx(self) -> Optional[CowBlobConfig]:
+        return self._context_var.get()
+
+    @staticmethod
+    def _should_intercept(ctx: CowBlobConfig, object_name: str) -> bool:
+        prefix = ctx.path_prefix
+        ns = ctx.scratch_namespace
+        if prefix and not object_name.startswith(prefix):
+            return False
+        rel = object_name[len(prefix) :] if prefix else object_name
+        if rel.startswith(f"{ns}/"):
+            return False
+        return True
+
+    @staticmethod
+    def _relative_name(ctx: CowBlobConfig, object_name: str) -> str:
+        prefix = ctx.path_prefix
+        if prefix and object_name.startswith(prefix):
+            return object_name[len(prefix) :]
+        return object_name
+
+    @staticmethod
+    def _session_id(ctx: CowBlobConfig) -> uuid.UUID:
+        assert ctx.session_id is not None
+        return ctx.session_id
+
+    @staticmethod
+    def _operation_id(ctx: CowBlobConfig) -> uuid.UUID:
+        assert ctx.operation_id is not None
+        return ctx.operation_id
+
+    @staticmethod
+    def _cow_path_for(ctx: CowBlobConfig, object_name: str) -> str:
+        return to_cow_path(
+            ctx,
+            CowBlobInterceptor._session_id(ctx),
+            CowBlobInterceptor._relative_name(ctx, object_name),
+            CowBlobInterceptor._operation_id(ctx),
+        )
+
+    @staticmethod
+    def _tombstone_path_for(ctx: CowBlobConfig, object_name: str) -> str:
+        return to_tombstone_path(
+            ctx,
+            CowBlobInterceptor._session_id(ctx),
+            CowBlobInterceptor._relative_name(ctx, object_name),
+            CowBlobInterceptor._operation_id(ctx),
+        )
+
+    @staticmethod
+    def _accumulate(
+        ctx: CowBlobConfig,
+        bucket_name: str,
+        object_name: str,
+        is_delete: bool = False,
+    ) -> None:
+        op_id = CowBlobInterceptor._operation_id(ctx)
+        history = ctx.file_history.get(object_name)
+        if history:
+            last_op_id = history[-1][0]
+            if last_op_id != op_id:
+                ctx.dependencies.append((last_op_id, op_id))
+
+        ctx.file_history.setdefault(object_name, []).append(
+            (ctx.operation_id, is_delete)
+        )
+        cow_path = (
+            "" if is_delete else CowBlobInterceptor._cow_path_for(ctx, object_name)
+        )
+        ctx.pending_writes.append(
+            CowBlobRecord(
+                final_path=object_name,
+                is_delete=is_delete,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                bucket_name=bucket_name,
+                cow_path=cow_path,
+                operation_id=ctx.operation_id,
+            )
+        )
+
+    def _load_file_history(self, ctx: CowBlobConfig, bucket_name: str) -> None:
+        """Populate file_history by listing the session's S3 keys.
+
+        Blobs under ``blobs/`` are writes; keys under ``tombstones/``
+        are deletes.  Entries are sorted by ``LastModified`` so the
+        history reflects chronological order across requests.
+        """
+        if ctx.history_loaded:
+            return
+        ctx.history_loaded = True
+
+        prefix = cow_session_prefix(
+            ctx.path_prefix, self._session_id(ctx), ctx.scratch_namespace
+        )
+        paginator = self._s3_client.get_paginator("list_objects_v2")
+
+        entries: list[tuple[str, uuid.UUID, bool, datetime]] = []
+        for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                parsed = parse_cow_key(obj["Key"], prefix, ctx.path_prefix)
+                if parsed is None:
+                    continue
+                op_id, final_path, is_delete = parsed
+                entries.append((final_path, op_id, is_delete, obj["LastModified"]))
+
+        entries.sort(key=lambda e: e[3])
+
+        for final_path, op_id, is_delete, _ in entries:
+            ctx.file_history.setdefault(final_path, []).append((op_id, is_delete))
+
+    def _resolve_read_path(self, ctx: CowBlobConfig, object_name: str) -> Optional[str]:
+        """Return the path to read from, or None if deleted in this session."""
+        if not self._should_intercept(ctx, object_name):
+            return object_name
+
+        history = ctx.file_history.get(object_name)
+        if history:
+            last_op_id, is_delete = history[-1]
+            if is_delete:
+                return None
+            return to_cow_path(
+                ctx,
+                CowBlobInterceptor._session_id(ctx),
+                self._relative_name(ctx, object_name),
+                last_op_id,
+            )
+
+        return object_name
+
+    def _intercept_write(self, params, **kwargs):
+        ctx = self._get_ctx()
+        if ctx is None or ctx.session_id is None:
+            return
+        key = params.get("Key", "")
+        if not key or not self._should_intercept(ctx, key):
+            return
+        params["Key"] = self._cow_path_for(ctx, key)
+        self._accumulate(ctx, params["Bucket"], key)
+
+    def _intercept_read(self, params, **kwargs):
+        ctx = self._get_ctx()
+        if ctx is None or ctx.session_id is None:
+            return
+        key = params.get("Key", "")
+        if not key or not self._should_intercept(ctx, key):
+            return
+        self._load_file_history(ctx, params["Bucket"])
+        resolved = self._resolve_read_path(ctx, params["Key"])
+        if resolved is None:
+            raise FileNotFoundError(
+                f"Blob {params['Key']!r} has been deleted in this COW session"
+            )
+        params["Key"] = resolved
+
+    def record_delete(self, bucket_name: str, object_name: str) -> bool:
+        """Record a COW delete if a session is active.
+
+        Writes a zero-byte tombstone blob to S3 and updates the in-memory
+        file history. Returns True if the delete was intercepted (caller
+        should skip the actual S3 call), False otherwise.
+        """
+        ctx = self._get_ctx()
+        if (
+            ctx is None
+            or ctx.session_id is None
+            or not self._should_intercept(ctx, object_name)
+        ):
+            return False
+
+        tombstone = self._tombstone_path_for(ctx, object_name)
+        self._s3_client.put_object(Bucket=bucket_name, Key=tombstone, Body=b"")
+
+        self._accumulate(ctx, bucket_name, object_name, is_delete=True)
+        return True

--- a/agentcow/blob/operations.py
+++ b/agentcow/blob/operations.py
@@ -1,0 +1,293 @@
+"""
+High-level COW blob operations: commit, discard, cleanup, dependencies.
+
+Records are discovered by listing S3 keys under the session prefix
+(blobs/ for writes, tombstones/ for deletes) rather than reading
+manifest files.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections import defaultdict
+
+from .paths import cow_session_prefix, parse_cow_key
+from .context import BlobOperationDiff, CowBlobRecord
+
+logger = logging.getLogger(__name__)
+
+
+def _load_records_from_keys(
+    backend,
+    bucket: str,
+    path_prefix: str,
+    scratch_namespace: str,
+    session_id: uuid.UUID,
+    operation_ids: list[uuid.UUID] | None = None,
+) -> list[CowBlobRecord]:
+    """Build CowBlobRecords by listing and parsing S3 keys under the session prefix."""
+    prefix = cow_session_prefix(path_prefix, session_id, scratch_namespace)
+    blobs = backend.list_blobs(bucket, prefix)
+
+    op_filter = set(operation_ids) if operation_ids is not None else None
+    records: list[CowBlobRecord] = []
+    for blob in blobs:
+        name = blob.name if hasattr(blob, "name") else str(blob)
+        parsed = parse_cow_key(name, prefix, path_prefix)
+        if parsed is None:
+            continue
+        op_id, final_path, is_delete = parsed
+        if op_filter is not None and op_id not in op_filter:
+            continue
+        records.append(
+            CowBlobRecord(
+                final_path=final_path,
+                is_delete=is_delete,
+                timestamp=blob.last_updated.isoformat() if blob.last_updated else "",
+                bucket_name=bucket,
+                cow_path=name,
+                operation_id=op_id,
+            )
+        )
+    return records
+
+
+def get_blob_session_operations(
+    backend,
+    manifest_bucket: str,
+    path_prefix: str,
+    scratch_namespace: str,
+    session_id: uuid.UUID,
+) -> list[uuid.UUID]:
+    """Return all uncommitted blob operation IDs for a COW session."""
+    records = _load_records_from_keys(
+        backend, manifest_bucket, path_prefix, scratch_namespace, session_id
+    )
+    seen: set[uuid.UUID] = set()
+    ops: list[uuid.UUID] = []
+    for rec in records:
+        if rec.operation_id and rec.operation_id not in seen:
+            seen.add(rec.operation_id)
+            ops.append(rec.operation_id)
+    return ops
+
+
+def get_blob_dependencies(
+    backend,
+    manifest_bucket: str,
+    path_prefix: str,
+    scratch_namespace: str,
+    session_id: uuid.UUID,
+) -> list[tuple[uuid.UUID, uuid.UUID]]:
+    """Compute blob operation dependencies from session keys.
+
+    When two operations touch the same ``final_path``, the one with the
+    earlier timestamp depends-on the later one.
+
+    Returns ``(depends_on, operation_id)`` pairs.
+    """
+    records = _load_records_from_keys(
+        backend, manifest_bucket, path_prefix, scratch_namespace, session_id
+    )
+
+    files: dict[str, list[tuple[uuid.UUID, str]]] = defaultdict(list)
+    for rec in records:
+        if rec.operation_id is not None:
+            files[rec.final_path].append((rec.operation_id, rec.timestamp))
+
+    deps: list[tuple[uuid.UUID, uuid.UUID]] = []
+    seen: set[tuple[uuid.UUID, uuid.UUID]] = set()
+    for entries in files.values():
+        if len(entries) < 2:
+            continue
+        entries.sort(key=lambda e: e[1])
+        for i in range(len(entries) - 1):
+            pair = (entries[i][0], entries[i + 1][0])
+            if pair not in seen:
+                seen.add(pair)
+                deps.append(pair)
+    return deps
+
+
+def _read_record_content(
+    backend,
+    bucket: str,
+    rec: CowBlobRecord,
+) -> str | None:
+    if rec.is_delete:
+        return None
+    return backend.download_as_string(bucket, rec.cow_path)
+
+
+def get_blob_operation_diff(
+    backend,
+    manifest_bucket: str,
+    path_prefix: str,
+    scratch_namespace: str,
+    session_id: uuid.UUID,
+    operation_id: uuid.UUID,
+) -> BlobOperationDiff:
+    """Compute before/after content for a single operation on a single file."""
+    records = _load_records_from_keys(
+        backend, manifest_bucket, path_prefix, scratch_namespace, session_id
+    )
+
+    target = next((r for r in records if r.operation_id == operation_id), None)
+    if target is None:
+        return BlobOperationDiff(
+            before_content=None,
+            after_content=None,
+            is_new_file=False,
+            is_delete=False,
+        )
+
+    after_content = _read_record_content(backend, manifest_bucket, target)
+
+    file_ops = sorted(
+        (
+            r
+            for r in records
+            if r.final_path == target.final_path and r.operation_id is not None
+        ),
+        key=lambda r: r.timestamp,
+    )
+    target_idx = next(
+        (i for i, r in enumerate(file_ops) if r.operation_id == operation_id), None
+    )
+
+    if target_idx is not None and target_idx > 0:
+        prev = file_ops[target_idx - 1]
+        before_content = _read_record_content(backend, manifest_bucket, prev)
+        is_new_file = prev.is_delete
+    elif backend.blob_exists(manifest_bucket, target.final_path):
+        before_content = backend.download_as_string(manifest_bucket, target.final_path)
+        is_new_file = before_content == after_content
+        if is_new_file:
+            before_content = None
+    else:
+        before_content = None
+        is_new_file = True
+
+    return BlobOperationDiff(
+        before_content=before_content,
+        after_content=after_content,
+        is_new_file=is_new_file,
+        is_delete=target.is_delete,
+    )
+
+
+def commit_cow_blobs(
+    backend,
+    manifest_bucket: str,
+    path_prefix: str,
+    scratch_namespace: str,
+    session_id: uuid.UUID,
+    operation_ids: list[uuid.UUID] | None = None,
+) -> int:
+    """Commit COW blobs: copy writes to production, apply deletes, clean up.
+
+    Records are sorted by timestamp so multi-operation commits apply
+    in the correct order.  Returns the number of records processed.
+    """
+    records = _load_records_from_keys(
+        backend,
+        manifest_bucket,
+        path_prefix,
+        scratch_namespace,
+        session_id,
+        operation_ids,
+    )
+    records.sort(key=lambda r: r.timestamp)
+
+    for rec in records:
+        if rec.is_delete:
+            if backend.blob_exists(rec.bucket_name, rec.final_path):
+                backend.delete_file(rec.bucket_name, rec.final_path)
+        else:
+            data = backend.download_as_bytes(rec.bucket_name, rec.cow_path)
+            if data is not None:
+                backend.upload_binary(data, rec.bucket_name, rec.final_path)
+
+    _cleanup_session(
+        backend,
+        manifest_bucket,
+        path_prefix,
+        scratch_namespace,
+        session_id,
+        operation_ids,
+    )
+
+    logger.info(
+        "Committed %d cow blob records for session %s", len(records), session_id
+    )
+    return len(records)
+
+
+def discard_cow_blobs(
+    backend,
+    manifest_bucket: str,
+    path_prefix: str,
+    scratch_namespace: str,
+    session_id: uuid.UUID,
+    operation_ids: list[uuid.UUID] | None = None,
+) -> int:
+    """Discard COW blobs: delete scratch paths and tombstones.
+
+    Returns the number of records processed.
+    """
+    records = _load_records_from_keys(
+        backend,
+        manifest_bucket,
+        path_prefix,
+        scratch_namespace,
+        session_id,
+        operation_ids,
+    )
+
+    _cleanup_session(
+        backend,
+        manifest_bucket,
+        path_prefix,
+        scratch_namespace,
+        session_id,
+        operation_ids,
+    )
+
+    logger.info(
+        "Discarded %d cow blob records for session %s", len(records), session_id
+    )
+    return len(records)
+
+
+def _cleanup_session(
+    backend,
+    manifest_bucket: str,
+    path_prefix: str,
+    scratch_namespace: str,
+    session_id: uuid.UUID,
+    operation_ids: list[uuid.UUID] | None = None,
+) -> None:
+    """Remove COW scratch blobs and tombstones.
+
+    When ``operation_ids`` is None the entire session prefix is wiped.
+    When scoped, only the referenced blobs/tombstones are removed.
+    """
+    if operation_ids is None:
+        prefix = cow_session_prefix(path_prefix, session_id, scratch_namespace)
+        blobs = backend.list_blobs(manifest_bucket, prefix)
+        for blob in blobs:
+            backend.delete_file(manifest_bucket, blob.name)
+        return
+
+    records = _load_records_from_keys(
+        backend,
+        manifest_bucket,
+        path_prefix,
+        scratch_namespace,
+        session_id,
+        operation_ids,
+    )
+    for rec in records:
+        if rec.cow_path and backend.blob_exists(manifest_bucket, rec.cow_path):
+            backend.delete_file(manifest_bucket, rec.cow_path)

--- a/agentcow/blob/operations.py
+++ b/agentcow/blob/operations.py
@@ -73,6 +73,25 @@ def get_blob_session_operations(
     return ops
 
 
+def get_blob_session_records(
+    backend,
+    manifest_bucket: str,
+    path_prefix: str,
+    scratch_namespace: str,
+    session_id: uuid.UUID,
+    operation_ids: list[uuid.UUID] | None = None,
+) -> list[CowBlobRecord]:
+    """Return blob operation records for a COW session."""
+    return _load_records_from_keys(
+        backend,
+        manifest_bucket,
+        path_prefix,
+        scratch_namespace,
+        session_id,
+        operation_ids,
+    )
+
+
 def get_blob_dependencies(
     backend,
     manifest_bucket: str,

--- a/agentcow/blob/paths.py
+++ b/agentcow/blob/paths.py
@@ -90,6 +90,9 @@ def parse_cow_key(
 ) -> tuple[uuid.UUID, str, bool] | None:
     """Parse a COW S3 key into (operation_id, final_path, is_delete).
 
+    ``path_prefix`` is concatenated with the key's relative path; include a
+    trailing ``/`` when production keys live under a directory (e.g. ``data/``).
+
     Returns None for keys that aren't blobs or tombstones (e.g. old manifests).
 
     Expected formats::

--- a/agentcow/blob/paths.py
+++ b/agentcow/blob/paths.py
@@ -1,0 +1,127 @@
+"""
+Path construction and parsing for COW blob operations.
+
+All functions are pure — no I/O, no driver-specific imports.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .context import CowBlobConfig
+
+
+def _extract_prefix_and_ns(
+    ctx_or_prefix: CowBlobConfig | str,
+    scratch_namespace: str | None = None,
+) -> tuple[str, str]:
+    if isinstance(ctx_or_prefix, str):
+        return ctx_or_prefix, scratch_namespace or ".cow"
+    return ctx_or_prefix.path_prefix, ctx_or_prefix.scratch_namespace
+
+
+def to_cow_path(
+    ctx_or_prefix: CowBlobConfig | str,
+    session_id: uuid.UUID,
+    object_name: str,
+    operation_id: uuid.UUID,
+    scratch_namespace: str | None = None,
+) -> str:
+    """Build the operation-scoped scratch path for a COW write."""
+    prefix, ns = _extract_prefix_and_ns(ctx_or_prefix, scratch_namespace)
+    return f"{prefix}{ns}/session_{session_id}/blobs/{operation_id}/{object_name}"
+
+
+def to_tombstone_path(
+    ctx_or_prefix: CowBlobConfig | str,
+    session_id: uuid.UUID,
+    object_name: str,
+    operation_id: uuid.UUID,
+    scratch_namespace: str | None = None,
+) -> str:
+    """Build the operation-scoped path for a COW delete tombstone."""
+    prefix, ns = _extract_prefix_and_ns(ctx_or_prefix, scratch_namespace)
+    return f"{prefix}{ns}/session_{session_id}/tombstones/{operation_id}/{object_name}"
+
+
+def to_manifest_path(
+    ctx_or_prefix: CowBlobConfig | str,
+    session_id: uuid.UUID,
+    operation_id: uuid.UUID,
+    scratch_namespace: str | None = None,
+) -> str:
+    prefix, ns = _extract_prefix_and_ns(ctx_or_prefix, scratch_namespace)
+    return f"{prefix}{ns}/session_{session_id}/.ops/{operation_id}.json"
+
+
+def cow_session_prefix(
+    ctx_or_prefix: CowBlobConfig | str,
+    session_id: uuid.UUID,
+    scratch_namespace: str | None = None,
+) -> str:
+    prefix, ns = _extract_prefix_and_ns(ctx_or_prefix, scratch_namespace)
+    return f"{prefix}{ns}/session_{session_id}/"
+
+
+def is_infrastructure_path(path: str, scratch_namespace: str = ".cow") -> bool:
+    """Return True if the path is inside the COW scratch namespace."""
+    return f"{scratch_namespace}/session_" in path
+
+
+def strip_cow_prefix(
+    cow_path: str,
+    ctx_or_prefix: CowBlobConfig | str,
+    session_id: uuid.UUID,
+    scratch_namespace: str | None = None,
+) -> str:
+    """Recover the production-relative path from a COW path."""
+    session_prefix = cow_session_prefix(ctx_or_prefix, session_id, scratch_namespace)
+    if not cow_path.startswith(session_prefix):
+        raise ValueError(
+            f"Path {cow_path!r} does not start with session prefix {session_prefix!r}"
+        )
+    return cow_path[len(session_prefix) :]
+
+
+def parse_cow_key(
+    key: str, session_prefix: str, path_prefix: str
+) -> tuple[uuid.UUID, str, bool] | None:
+    """Parse a COW S3 key into (operation_id, final_path, is_delete).
+
+    Returns None for keys that aren't blobs or tombstones (e.g. old manifests).
+
+    Expected formats::
+
+        {session_prefix}blobs/{operation_id}/{relative_path}
+        {session_prefix}tombstones/{operation_id}/{relative_path}
+    """
+    if not key.startswith(session_prefix):
+        return None
+
+    rest = key[len(session_prefix) :]
+
+    if rest.startswith("blobs/"):
+        is_delete = False
+        rest = rest[len("blobs/") :]
+    elif rest.startswith("tombstones/"):
+        is_delete = True
+        rest = rest[len("tombstones/") :]
+    else:
+        return None
+
+    slash_idx = rest.find("/")
+    if slash_idx == -1:
+        return None
+
+    op_id_str = rest[:slash_idx]
+    relative_path = rest[slash_idx + 1 :]
+
+    try:
+        op_id = uuid.UUID(op_id_str)
+    except ValueError:
+        return None
+
+    final_path = f"{path_prefix}{relative_path}"
+    return (op_id, final_path, is_delete)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,16 @@ sqlalchemy = [
     "sqlalchemy>=2.0.0",
     "asyncpg>=0.29.0",
 ]
+blob = [
+    "boto3>=1.28.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-postgresql>=6.0.0",
     "sqlalchemy>=2.0.0",
     "asyncpg>=0.29.0",
+    "boto3>=1.28.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
the blob implementation works by intercepting S3 operations at the library level (using boto3 event hooks -- so it is dependent on using the boto3 library for blob operations).
- `Put` operations get intercepted and redirected to a cow-aware path in the same directory as the original folder
- `Get` operations get redirected to the cow-aware path as well
- `Delete` operations write an empty blob file to a tombstones/{deletion_op_id}/{relative_file_path} folder (read operations to this folder return `FileNotFound`)

it can be used with the shared CowConfig class/config manager if its implemented alongside a postgresql implementation

Test Plan:
this has been implemented/used in trail for a couple weeks now, I will also add some proper tests in the next PR
