### PR TITLE
make the defer constraints optional, instead using operation-dependent ordering

### DIFF
--- a/agentcow/postgres/README.md
+++ b/agentcow/postgres/README.md
@@ -186,8 +186,8 @@ for stmt in stmts:
 | Function | Description |
 |----------|-------------|
 | `deploy_cow_functions(executor)` | Deploy COW PL/pgSQL functions to the database |
-| `enable_cow(executor, table_name, *, pk_cols=None, schema="public")` | Enable COW on a single table. Primary keys are auto-detected if not provided |
-| `enable_cow_schema(executor, *, schema="public", exclude=None)` | Enable COW on all user tables in a schema. Returns list of enabled table names |
+| `enable_cow(executor, table_name, *, pk_cols=None, schema="public", allow_deferred_fks=False)` | Enable COW on a single table. Primary keys are auto-detected if not provided. See [FK constraints](#fk-constraints-and-multi-table-commits) for `allow_deferred_fks` |
+| `enable_cow_schema(executor, *, schema="public", exclude=None, allow_deferred_fks=False)` | Enable COW on all user tables in a schema. Returns list of enabled table names |
 
 ### Per-Request
 
@@ -212,6 +212,7 @@ for stmt in stmts:
 | Function | Description |
 |----------|-------------|
 | `commit_cow_session(executor, table_name, session_id, *, pk_cols=None, schema="public")` | Commit all session changes to the base table |
+| `commit_cow_session_schema(executor, session_id, *, schema="public", defer_fk_constraints=False)` | Commit every dirty table for the session. Orders by FK dependency by default — see [FK constraints](#fk-constraints-and-multi-table-commits) |
 | `discard_cow_session(executor, table_name, session_id, *, schema="public")` | Discard all session changes |
 | `commit_cow_operations(executor, table_name, session_id, operation_ids, *, pk_cols=None, schema="public")` | Commit specific operations (cherry-pick) |
 | `discard_cow_operations(executor, table_name, session_id, operation_ids, *, schema="public")` | Discard specific operations |
@@ -220,8 +221,33 @@ for stmt in stmts:
 
 | Function | Description |
 |----------|-------------|
-| `disable_cow(executor, table_name, *, schema="public")` | Disable COW on a table, restoring the original base table |
-| `disable_cow_schema(executor, *, schema="public", exclude=None)` | Disable COW on all COW-enabled tables in a schema |
+| `disable_cow(executor, table_name, *, schema="public", revert_deferred_fks=True)` | Disable COW on a table, restoring the original base table. Reverts any `DEFERRABLE INITIALLY IMMEDIATE` FKs back to `NOT DEFERRABLE` |
+| `disable_cow_schema(executor, *, schema="public", exclude=None, revert_deferred_fks=True)` | Disable COW on all COW-enabled tables in a schema |
+
+## FK Constraints and Multi-Table Commits
+
+When you commit a session that spans multiple tables with foreign keys between them, the commit order matters:
+
+- Parents must be inserted before children (new user → new project referencing that user)
+- Children must be deleted before parents (delete project → delete its owner)
+
+By default, `commit_cow_session_schema` discovers the FK graph between your dirty tables, topologically sorts them, and commits in two phases: upserts run parents-first and deletes run children-first. This keeps the database consistent at every step without any schema modifications — your FK constraints stay exactly as you defined them.
+
+If the dirty-table subgraph contains an FK **cycle**, the library raises `ValueError` at commit time. Cycles genuinely can't be ordered row-by-row; you need constraint deferral to commit them.
+
+For cycles, self-referential FKs, or bulk loads where you'd rather rely on Postgres to defer FK checks until end-of-transaction, opt in with:
+
+```python
+# One-time: flip the relevant FKs to DEFERRABLE INITIALLY IMMEDIATE
+await enable_cow_schema(executor, allow_deferred_fks=True)
+
+# Per-commit: use SET CONSTRAINTS ALL DEFERRED around the loop
+await commit_cow_session_schema(executor, session_id, defer_fk_constraints=True)
+```
+
+`enable_cow(..., allow_deferred_fks=True)` only flips constraints that are currently `NOT DEFERRABLE`. Constraints that are `INITIALLY DEFERRED` (a deliberate schema choice) are left alone. `disable_cow` reverses the flip.
+
+Without the opt-in, **no schema changes** are made by agent-cow.
 
 ### Types
 

--- a/agentcow/postgres/core.py
+++ b/agentcow/postgres/core.py
@@ -7,18 +7,23 @@ All functions accept a generic ``Executor`` — no ORM or driver dependency.
 
 import uuid
 from contextlib import asynccontextmanager
+from graphlib import CycleError, TopologicalSorter
 from typing import Any, AsyncIterator, Protocol, TypedDict, runtime_checkable
 
 from .cow_sql_functions import (
     COW_CHANGES_TABLE_NAME_SQL,
     CREATE_DIRTY_TABLES_SQL,
     SETUP_COW_SQL,
+    COMMIT_COW_UPSERT_SQL,
+    COMMIT_COW_DELETE_SQL,
+    COMMIT_COW_CLEANUP_SQL,
     COMMIT_COW_SQL,
     DISCARD_COW_SQL,
     TEARDOWN_COW_SQL,
     GET_DIRTY_CHANGES_TABLES_SQL,
     GET_COW_DEPENDENCIES_SQL,
     GET_SESSION_OPERATIONS_SQL,
+    GET_COW_FK_EDGES_SQL,
 )
 from .operations import (
     COW_FUNCTION_NAMES,
@@ -37,6 +42,12 @@ from .operations import (
     discard_cow_session_sql,
     commit_cow_operations_sql,
     discard_cow_operations_sql,
+    commit_cow_upsert_sql,
+    commit_cow_delete_sql,
+    commit_cow_cleanup_sql,
+    get_cow_fk_edges_sql,
+    alter_fk_constraints_deferrable_sql,
+    alter_fk_constraints_not_deferrable_sql,
     get_session_operations_sql,
     get_operation_dependencies_sql,
     set_visible_operations_sql,
@@ -101,11 +112,40 @@ async def deferred_fk_constraints(executor: Executor) -> AsyncIterator[None]:
 
     Use this around multi-table commit loops so that cross-table FK
     references are validated only after all tables have been committed.
-    Requires FK constraints to be ``DEFERRABLE INITIALLY IMMEDIATE``.
+    Requires FK constraints to be ``DEFERRABLE INITIALLY IMMEDIATE``
+    (see :func:`enable_cow` / :func:`enable_cow_schema` with
+    ``allow_deferred_fks=True``).
     """
     await executor.execute("SET CONSTRAINTS ALL DEFERRED")
     yield
     await executor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+
+def _topologically_sort_tables(
+    tables: list[str],
+    edges: list[tuple[str, str]],
+) -> list[str]:
+    """Return *tables* ordered so that parents come before children.
+
+    Raises :class:`ValueError` with actionable remediation if the FK
+    subgraph contains a cycle.
+    """
+    sorter: TopologicalSorter[str] = TopologicalSorter()
+    for table in tables:
+        sorter.add(table)
+    for parent, child in edges:
+        if parent != child:
+            sorter.add(child, parent)
+    try:
+        return list(sorter.static_order())
+    except CycleError as exc:
+        cycle = list(dict.fromkeys(exc.args[1]))
+        raise ValueError(
+            f"Cycle detected among tables {cycle}; commit_cow_session_schema "
+            "cannot order inserts/deletes automatically. Either break the cycle "
+            "in your schema or pass defer_fk_constraints=True (requires FKs to "
+            "be DEFERRABLE; see enable_cow(allow_deferred_fks=True))."
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -119,12 +159,16 @@ async def deploy_cow_functions(executor: Executor) -> None:
         COW_CHANGES_TABLE_NAME_SQL,
         CREATE_DIRTY_TABLES_SQL,
         SETUP_COW_SQL,
+        COMMIT_COW_UPSERT_SQL,
+        COMMIT_COW_DELETE_SQL,
+        COMMIT_COW_CLEANUP_SQL,
         COMMIT_COW_SQL,
         DISCARD_COW_SQL,
         TEARDOWN_COW_SQL,
         GET_DIRTY_CHANGES_TABLES_SQL,
         GET_COW_DEPENDENCIES_SQL,
         GET_SESSION_OPERATIONS_SQL,
+        GET_COW_FK_EDGES_SQL,
     ):
         await executor.execute(sql)
 
@@ -139,10 +183,19 @@ async def enable_cow(
     table_name: str,
     pk_cols: list[str] | None = None,
     schema: str = "public",
+    allow_deferred_fks: bool = False,
 ) -> None:
     """Enable COW on *table_name*.
 
     If *pk_cols* is ``None`` they are auto-detected from the database.
+
+    If *allow_deferred_fks* is ``True``, any ``NOT DEFERRABLE`` FK
+    constraints on the base table are flipped to
+    ``DEFERRABLE INITIALLY IMMEDIATE`` so that callers can use
+    :func:`deferred_fk_constraints` or
+    ``commit_cow_session_schema(..., defer_fk_constraints=True)``.
+    This modifies your schema; by default we leave constraints alone
+    and rely on topological-order commits to satisfy FK checks.
     """
     base_table = f"{table_name}_base"
 
@@ -153,28 +206,40 @@ async def enable_cow(
     base_exists, original_is_table, view_exists = rows[0]
 
     if base_exists and view_exists:
+        if allow_deferred_fks:
+            await executor.execute(
+                alter_fk_constraints_deferrable_sql(schema, base_table)
+            )
         return
 
     if base_exists and not view_exists:
         await executor.execute(setup_cow_sql(schema, base_table, table_name, pk_cols))
-        return
-
-    if original_is_table:
+    elif original_is_table:
         await executor.execute(rename_table_sql(schema, table_name, base_table))
         await executor.execute(setup_cow_sql(schema, base_table, table_name, pk_cols))
-        return
+    else:
+        raise ValueError(
+            f"Table {table_name} not found in schema {schema} as table or view"
+        )
 
-    raise ValueError(
-        f"Table {table_name} not found in schema {schema} as table or view"
-    )
+    if allow_deferred_fks:
+        await executor.execute(alter_fk_constraints_deferrable_sql(schema, base_table))
 
 
 async def disable_cow(
     executor: Executor,
     table_name: str,
     schema: str = "public",
+    revert_deferred_fks: bool = True,
 ) -> None:
-    """Disable COW for *table_name*, restoring the original base table."""
+    """Disable COW for *table_name*, restoring the original base table.
+
+    If *revert_deferred_fks* is ``True`` (the default), any
+    ``DEFERRABLE INITIALLY IMMEDIATE`` FK constraints on the base table
+    are flipped back to ``NOT DEFERRABLE`` before the table is renamed.
+    Constraints that are ``INITIALLY DEFERRED`` (explicitly set by the
+    schema owner) are left alone.
+    """
     base_table = f"{table_name}_base"
     changes_table = f"{table_name}_changes"
 
@@ -185,6 +250,11 @@ async def disable_cow(
 
     if not base_exists and not view_exists and not changes_exists:
         return
+
+    if base_exists and revert_deferred_fks:
+        await executor.execute(
+            alter_fk_constraints_not_deferrable_sql(schema, base_table)
+        )
 
     await executor.execute(teardown_cow_sql(schema, table_name))
 
@@ -200,11 +270,14 @@ async def enable_cow_schema(
     executor: Executor,
     schema: str = "public",
     exclude: set[str] | None = None,
+    allow_deferred_fks: bool = False,
 ) -> list[str]:
     """Enable COW on all user tables in *schema*.
 
     Tables whose names end with ``_base`` or ``_changes`` are skipped
     automatically, as are any names listed in *exclude*.
+
+    See :func:`enable_cow` for *allow_deferred_fks*.
 
     Returns the table names that were enabled.
     """
@@ -219,7 +292,12 @@ async def enable_cow_schema(
     for (table_name,) in rows:
         if table_name in exclude or table_name in already_cow:
             continue
-        await enable_cow(executor, table_name, schema=schema)
+        await enable_cow(
+            executor,
+            table_name,
+            schema=schema,
+            allow_deferred_fks=allow_deferred_fks,
+        )
         enabled.append(table_name)
     return enabled
 
@@ -228,6 +306,7 @@ async def disable_cow_schema(
     executor: Executor,
     schema: str = "public",
     exclude: set[str] | None = None,
+    revert_deferred_fks: bool = True,
 ) -> list[str]:
     """Disable COW on all COW-enabled tables in *schema*.
 
@@ -240,7 +319,12 @@ async def disable_cow_schema(
         table_name = base_name.removesuffix("_base")
         if table_name in exclude:
             continue
-        await disable_cow(executor, table_name, schema=schema)
+        await disable_cow(
+            executor,
+            table_name,
+            schema=schema,
+            revert_deferred_fks=revert_deferred_fks,
+        )
         disabled.append(table_name)
     return disabled
 
@@ -287,20 +371,90 @@ async def get_dirty_tables(
     return [row[0] for row in rows]
 
 
+async def _get_fk_edges(
+    executor: Executor,
+    schema: str,
+    base_tables: list[str],
+) -> list[tuple[str, str]]:
+    """Fetch FK edges ``(parent_view, child_view)`` among *base_tables*.
+
+    Returns view-level names (``_base`` suffix stripped). Self-referential
+    edges are dropped — they're a within-table ordering concern.
+    """
+    if not base_tables:
+        return []
+    rows = await executor.execute(get_cow_fk_edges_sql(schema, base_tables))
+    edges: list[tuple[str, str]] = []
+    for parent_base, child_base, is_self_ref in rows:
+        if is_self_ref:
+            continue
+        edges.append(
+            (
+                parent_base.removesuffix("_base"),
+                child_base.removesuffix("_base"),
+            )
+        )
+    return edges
+
+
 async def commit_cow_session_schema(
     executor: Executor,
     session_id: str | uuid.UUID,
     schema: str = "public",
+    defer_fk_constraints: bool = False,
 ) -> list[str]:
     """Commit all dirty tables for a session in a schema.
 
-    Returns the list of table names that were committed.
+    By default, tables are committed in two phases ordered by FK
+    dependency: upserts are applied parents-first (topological order),
+    then deletes are applied children-first (reverse topological order).
+    This keeps the database consistent at every intermediate step without
+    requiring any schema modifications.
+
+    If the dirty-table subgraph contains an FK cycle, a :class:`ValueError`
+    is raised; the caller can either break the cycle in their schema or
+    opt in to deferred checks with ``defer_fk_constraints=True`` (which
+    requires the FKs to be ``DEFERRABLE`` — see
+    ``enable_cow(allow_deferred_fks=True)``).
+
+    Returns the list of table names that were committed (in the order
+    they were processed).
     """
     tables = await get_dirty_tables(executor, session_id, schema)
-    async with deferred_fk_constraints(executor):
-        for table_name in tables:
-            await commit_cow_session(executor, table_name, session_id, schema=schema)
-    return tables
+    if not tables:
+        return []
+
+    if defer_fk_constraints:
+        async with deferred_fk_constraints(executor):
+            for table_name in tables:
+                await commit_cow_session(
+                    executor, table_name, session_id, schema=schema
+                )
+        return tables
+
+    base_tables = [f"{t}_base" for t in tables]
+    edges = await _get_fk_edges(executor, schema, base_tables)
+    ordered = _topologically_sort_tables(tables, edges)
+
+    for table_name in ordered:
+        base_table = f"{table_name}_base"
+        pk_cols = await _get_pk_cols(executor, schema, base_table)
+        await executor.execute(
+            commit_cow_upsert_sql(schema, base_table, pk_cols, session_id)
+        )
+
+    for table_name in reversed(ordered):
+        base_table = f"{table_name}_base"
+        pk_cols = await _get_pk_cols(executor, schema, base_table)
+        await executor.execute(
+            commit_cow_delete_sql(schema, base_table, pk_cols, session_id)
+        )
+
+    for table_name in ordered:
+        base_table = f"{table_name}_base"
+        await executor.execute(commit_cow_cleanup_sql(schema, base_table, session_id))
+
+    return ordered
 
 
 async def discard_cow_session_schema(

--- a/agentcow/postgres/cow_sql_functions.py
+++ b/agentcow/postgres/cow_sql_functions.py
@@ -511,10 +511,34 @@ RETURNS void
 LANGUAGE plpgsql
 AS $$
 DECLARE
+    base_table_name    text := p_view_name || '_base';
+    qual_base          text := format('%I.%I', p_schema, base_table_name);
     changes_table_name text := p_view_name || '_changes';
     upsert_fn_name     text := p_view_name || '_cow_upsert';
     delete_fn_name     text := p_view_name || '_cow_delete';
+    r                  RECORD;
 BEGIN
+    -- Revert FK constraints on the base table to NOT DEFERRABLE, undoing
+    -- what setup_cow did. Only touch constraints we know we flipped
+    -- (DEFERRABLE INITIALLY IMMEDIATE); leave any that were already
+    -- DEFERRABLE INITIALLY DEFERRED alone.
+    FOR r IN
+        SELECT con.conname
+        FROM pg_constraint con
+        JOIN pg_class cls ON con.conrelid = cls.oid
+        JOIN pg_namespace ns ON cls.relnamespace = ns.oid
+        WHERE con.contype = 'f'
+          AND ns.nspname = p_schema
+          AND cls.relname = base_table_name
+          AND con.condeferrable
+          AND NOT con.condeferred
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %s ALTER CONSTRAINT %I NOT DEFERRABLE',
+            qual_base, r.conname
+        );
+    END LOOP;
+
     EXECUTE format('DROP VIEW IF EXISTS %I.%I CASCADE', p_schema, p_view_name);
     EXECUTE format('DROP TABLE IF EXISTS %I.%I CASCADE', p_schema, changes_table_name);
     EXECUTE format('DROP FUNCTION IF EXISTS %I.%I()', p_schema, upsert_fn_name);

--- a/agentcow/postgres/cow_sql_functions.py
+++ b/agentcow/postgres/cow_sql_functions.py
@@ -67,7 +67,6 @@ DECLARE
     base_table_owner     text;
     base_on_conflict     text;
     changes_on_conflict  text;
-    r                    RECORD;
 BEGIN
     pk_cols_quoted := (SELECT string_agg(quote_ident(col), ', ') FROM unnest(p_pk_cols) col);
     pk_join_condition := (SELECT string_agg(format('c2.%I = b.%I', col, col), ' AND ') FROM unnest(p_pk_cols) col);
@@ -104,24 +103,6 @@ BEGIN
         changes_table_name || '_session_pk_idx',
         qual_changes, pk_cols_quoted
     );
-
-    -- 1b. Make FK constraints on the base table deferrable so that
-    --     multi-table COW commits can defer cross-table checks.
-    FOR r IN
-        SELECT con.conname
-        FROM pg_constraint con
-        JOIN pg_class cls ON con.conrelid = cls.oid
-        JOIN pg_namespace ns ON cls.relnamespace = ns.oid
-        WHERE con.contype = 'f'
-          AND ns.nspname = p_schema
-          AND cls.relname = p_base_table
-          AND NOT con.condeferrable
-    LOOP
-        EXECUTE format(
-            'ALTER TABLE %s ALTER CONSTRAINT %I DEFERRABLE INITIALLY IMMEDIATE',
-            qual_base, r.conname
-        );
-    END LOOP;
 
     -- 2. Build column lists from the base table
     SELECT
@@ -325,8 +306,8 @@ END;
 $$;
 """
 
-COMMIT_COW_SQL = """
-CREATE OR REPLACE FUNCTION commit_cow(
+COMMIT_COW_UPSERT_SQL = """
+CREATE OR REPLACE FUNCTION commit_cow_upsert(
     p_schema          text,
     p_base_table      text,
     p_pk_cols         text[],
@@ -339,15 +320,11 @@ AS $$
 DECLARE
     qual_base          text := format('%I.%I', p_schema, p_base_table);
     qual_changes       text := format('%I.%I', p_schema, _cow_changes_table_name(p_base_table));
-    p_view_name        text := regexp_replace(p_base_table, '_base$', '');
     pk_cols_quoted     text;
-    pk_join_condition  text;
     update_set_clause  text;
     col_list           text;
-    has_remaining      boolean;
 BEGIN
     pk_cols_quoted := (SELECT string_agg(quote_ident(col), ', ') FROM unnest(p_pk_cols) col);
-    pk_join_condition := (SELECT string_agg(format('c.%I = b.%I', col, col), ' AND ') FROM unnest(p_pk_cols) col);
 
     SELECT string_agg(quote_ident(column_name), ', ' ORDER BY ordinal_position)
     INTO col_list
@@ -393,6 +370,29 @@ BEGIN
         $sql$, qual_base, col_list, pk_cols_quoted, qual_changes, pk_cols_quoted, pk_cols_quoted, update_set_clause)
         USING p_session, p_operation_ids;
     END IF;
+END;
+$$;
+"""
+
+COMMIT_COW_DELETE_SQL = """
+CREATE OR REPLACE FUNCTION commit_cow_delete(
+    p_schema          text,
+    p_base_table      text,
+    p_pk_cols         text[],
+    p_session         uuid,
+    p_operation_ids   uuid[] DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    qual_base          text := format('%I.%I', p_schema, p_base_table);
+    qual_changes       text := format('%I.%I', p_schema, _cow_changes_table_name(p_base_table));
+    pk_cols_quoted     text;
+    pk_join_condition  text;
+BEGIN
+    pk_cols_quoted := (SELECT string_agg(quote_ident(col), ', ') FROM unnest(p_pk_cols) col);
+    pk_join_condition := (SELECT string_agg(format('c.%I = b.%I', col, col), ' AND ') FROM unnest(p_pk_cols) col);
 
     EXECUTE format($sql$
         DELETE FROM %s b
@@ -406,14 +406,31 @@ BEGIN
         WHERE c._cow_deleted = TRUE AND %s
     $sql$, qual_base, pk_cols_quoted, qual_changes, pk_cols_quoted, pk_join_condition)
     USING p_session, p_operation_ids;
+END;
+$$;
+"""
 
+COMMIT_COW_CLEANUP_SQL = """
+CREATE OR REPLACE FUNCTION commit_cow_cleanup(
+    p_schema          text,
+    p_base_table      text,
+    p_session         uuid,
+    p_operation_ids   uuid[] DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    qual_changes   text := format('%I.%I', p_schema, _cow_changes_table_name(p_base_table));
+    p_view_name    text := regexp_replace(p_base_table, '_base$', '');
+    has_remaining  boolean;
+BEGIN
     EXECUTE format(
         'DELETE FROM %s WHERE session_id = $1 AND ($2::uuid[] IS NULL OR operation_id = ANY($2))',
         qual_changes
     )
     USING p_session, p_operation_ids;
 
-    -- Clean up dirty table entry if no changes remain for this session+table
     EXECUTE format(
         'SELECT EXISTS(SELECT 1 FROM %s WHERE session_id = $1 LIMIT 1)',
         qual_changes
@@ -425,6 +442,25 @@ BEGIN
           AND session_id = p_session
           AND table_name = p_view_name;
     END IF;
+END;
+$$;
+"""
+
+COMMIT_COW_SQL = """
+CREATE OR REPLACE FUNCTION commit_cow(
+    p_schema          text,
+    p_base_table      text,
+    p_pk_cols         text[],
+    p_session         uuid,
+    p_operation_ids   uuid[] DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM commit_cow_upsert(p_schema, p_base_table, p_pk_cols, p_session, p_operation_ids);
+    PERFORM commit_cow_delete(p_schema, p_base_table, p_pk_cols, p_session, p_operation_ids);
+    PERFORM commit_cow_cleanup(p_schema, p_base_table, p_session, p_operation_ids);
 END;
 $$;
 """
@@ -677,5 +713,31 @@ BEGIN
         ORDER BY earliest_change
     $q$, query) USING p_session_id;
 END;
+$$;
+"""
+
+GET_COW_FK_EDGES_SQL = """
+CREATE OR REPLACE FUNCTION _cow_fk_edges(
+    p_schema      text,
+    p_base_tables text[]
+)
+RETURNS TABLE(parent_base_table text, child_base_table text, is_self_ref boolean)
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT DISTINCT
+        parent_cls.relname::text AS parent_base_table,
+        child_cls.relname::text  AS child_base_table,
+        (parent_cls.oid = child_cls.oid) AS is_self_ref
+    FROM pg_constraint con
+    JOIN pg_class child_cls ON con.conrelid = child_cls.oid
+    JOIN pg_namespace child_ns ON child_cls.relnamespace = child_ns.oid
+    JOIN pg_class parent_cls ON con.confrelid = parent_cls.oid
+    JOIN pg_namespace parent_ns ON parent_cls.relnamespace = parent_ns.oid
+    WHERE con.contype = 'f'
+      AND child_ns.nspname = p_schema
+      AND parent_ns.nspname = p_schema
+      AND child_cls.relname = ANY(p_base_tables)
+      AND parent_cls.relname = ANY(p_base_tables);
 $$;
 """

--- a/agentcow/postgres/cow_sql_functions.py
+++ b/agentcow/postgres/cow_sql_functions.py
@@ -475,10 +475,34 @@ RETURNS void
 LANGUAGE plpgsql
 AS $$
 DECLARE
+    base_table_name    text := p_view_name || '_base';
+    qual_base          text := format('%I.%I', p_schema, base_table_name);
     changes_table_name text := p_view_name || '_changes';
     upsert_fn_name     text := p_view_name || '_cow_upsert';
     delete_fn_name     text := p_view_name || '_cow_delete';
+    r                  RECORD;
 BEGIN
+    -- Revert FK constraints on the base table to NOT DEFERRABLE, undoing
+    -- what setup_cow did. Only touch constraints we know we flipped
+    -- (DEFERRABLE INITIALLY IMMEDIATE); leave any that were already
+    -- DEFERRABLE INITIALLY DEFERRED alone.
+    FOR r IN
+        SELECT con.conname
+        FROM pg_constraint con
+        JOIN pg_class cls ON con.conrelid = cls.oid
+        JOIN pg_namespace ns ON cls.relnamespace = ns.oid
+        WHERE con.contype = 'f'
+          AND ns.nspname = p_schema
+          AND cls.relname = base_table_name
+          AND con.condeferrable
+          AND NOT con.condeferred
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %s ALTER CONSTRAINT %I NOT DEFERRABLE',
+            qual_base, r.conname
+        );
+    END LOOP;
+
     EXECUTE format('DROP VIEW IF EXISTS %I.%I CASCADE', p_schema, p_view_name);
     EXECUTE format('DROP TABLE IF EXISTS %I.%I CASCADE', p_schema, changes_table_name);
     EXECUTE format('DROP FUNCTION IF EXISTS %I.%I()', p_schema, upsert_fn_name);

--- a/agentcow/postgres/cow_sql_functions.py
+++ b/agentcow/postgres/cow_sql_functions.py
@@ -475,34 +475,10 @@ RETURNS void
 LANGUAGE plpgsql
 AS $$
 DECLARE
-    base_table_name    text := p_view_name || '_base';
-    qual_base          text := format('%I.%I', p_schema, base_table_name);
     changes_table_name text := p_view_name || '_changes';
     upsert_fn_name     text := p_view_name || '_cow_upsert';
     delete_fn_name     text := p_view_name || '_cow_delete';
-    r                  RECORD;
 BEGIN
-    -- Revert FK constraints on the base table to NOT DEFERRABLE, undoing
-    -- what setup_cow did. Only touch constraints we know we flipped
-    -- (DEFERRABLE INITIALLY IMMEDIATE); leave any that were already
-    -- DEFERRABLE INITIALLY DEFERRED alone.
-    FOR r IN
-        SELECT con.conname
-        FROM pg_constraint con
-        JOIN pg_class cls ON con.conrelid = cls.oid
-        JOIN pg_namespace ns ON cls.relnamespace = ns.oid
-        WHERE con.contype = 'f'
-          AND ns.nspname = p_schema
-          AND cls.relname = base_table_name
-          AND con.condeferrable
-          AND NOT con.condeferred
-    LOOP
-        EXECUTE format(
-            'ALTER TABLE %s ALTER CONSTRAINT %I NOT DEFERRABLE',
-            qual_base, r.conname
-        );
-    END LOOP;
-
     EXECUTE format('DROP VIEW IF EXISTS %I.%I CASCADE', p_schema, p_view_name);
     EXECUTE format('DROP TABLE IF EXISTS %I.%I CASCADE', p_schema, changes_table_name);
     EXECUTE format('DROP FUNCTION IF EXISTS %I.%I()', p_schema, upsert_fn_name);

--- a/agentcow/postgres/examples/sqlalchemy_example.py
+++ b/agentcow/postgres/examples/sqlalchemy_example.py
@@ -26,10 +26,10 @@ Requirements:
 from __future__ import annotations
 
 import asyncio
-import collections
 import traceback
 import uuid
 from contextlib import asynccontextmanager
+from graphlib import TopologicalSorter
 from typing import Any, AsyncIterator
 
 from sqlalchemy import Column, ForeignKey, Integer, String, event, inspect, select, text
@@ -199,34 +199,19 @@ def _toposort_models(
         if tbl:
             model_map[tbl] = m
 
-    deps: dict[type, set[type]] = collections.defaultdict(set)
+    sorter: TopologicalSorter[type[DeclarativeBase]] = TopologicalSorter()
     for model in models:
+        sorter.add(model)
         for col in inspect(model).columns:
             for fk in col.foreign_keys:
                 parts = fk.target_fullname.split(".")
-                if len(parts) >= 2:
-                    target = parts[-2]
-                    if target in model_map and model_map[target] is not model:
-                        deps[model].add(model_map[target])
+                if len(parts) < 2:
+                    continue
+                parent = model_map.get(parts[-2])
+                if parent is not None and parent is not model:
+                    sorter.add(model, parent)
 
-    result: list[type[DeclarativeBase]] = []
-    visited: set[type] = set()
-    visiting: set[type] = set()
-
-    def visit(node: type):
-        if node in visiting:
-            return
-        if node not in visited:
-            visiting.add(node)
-            for dep in deps[node]:
-                visit(dep)
-            visiting.discard(node)
-            visited.add(node)
-            result.append(node)
-
-    for m in models:
-        visit(m)
-    return result
+    return list(sorter.static_order())
 
 
 async def enable_cow_for_models(

--- a/agentcow/postgres/operations.py
+++ b/agentcow/postgres/operations.py
@@ -11,7 +11,15 @@ No driver-specific imports are used — only standard Python + raw SQL.
 import uuid
 
 
-COW_FUNCTION_NAMES = ("setup_cow", "commit_cow", "discard_cow", "teardown_cow")
+COW_FUNCTION_NAMES = (
+    "setup_cow",
+    "commit_cow",
+    "commit_cow_upsert",
+    "commit_cow_delete",
+    "commit_cow_cleanup",
+    "discard_cow",
+    "teardown_cow",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +256,162 @@ def commit_cow_session_sql(
         f"{_to_text_array(pk_cols)}, "
         f"{_to_uuid(session_id)})"
     )
+
+
+def commit_cow_upsert_sql(
+    schema: str,
+    base_table: str,
+    pk_cols: list[str],
+    session_id: str | uuid.UUID,
+    operation_ids: list[str | uuid.UUID] | None = None,
+) -> str:
+    """SQL to apply the upsert phase of a COW commit for one table.
+
+    Commits non-deleted rows only, leaving deletes and cleanup to
+    subsequent calls. Used by schema-level commits to phase inserts
+    and deletes across tables in FK dependency order.
+    """
+    ops = (
+        f"{_to_uuid_array(operation_ids)}"
+        if operation_ids
+        else "NULL::uuid[]"
+    )
+    return (
+        f"SELECT commit_cow_upsert("
+        f"{_quote_literal(schema)}, "
+        f"{_quote_literal(base_table)}, "
+        f"{_to_text_array(pk_cols)}, "
+        f"{_to_uuid(session_id)}, "
+        f"{ops})"
+    )
+
+
+def commit_cow_delete_sql(
+    schema: str,
+    base_table: str,
+    pk_cols: list[str],
+    session_id: str | uuid.UUID,
+    operation_ids: list[str | uuid.UUID] | None = None,
+) -> str:
+    """SQL to apply the delete phase of a COW commit for one table."""
+    ops = (
+        f"{_to_uuid_array(operation_ids)}"
+        if operation_ids
+        else "NULL::uuid[]"
+    )
+    return (
+        f"SELECT commit_cow_delete("
+        f"{_quote_literal(schema)}, "
+        f"{_quote_literal(base_table)}, "
+        f"{_to_text_array(pk_cols)}, "
+        f"{_to_uuid(session_id)}, "
+        f"{ops})"
+    )
+
+
+def commit_cow_cleanup_sql(
+    schema: str,
+    base_table: str,
+    session_id: str | uuid.UUID,
+    operation_ids: list[str | uuid.UUID] | None = None,
+) -> str:
+    """SQL to clean up the changes table and dirty-tables entry after a commit."""
+    ops = (
+        f"{_to_uuid_array(operation_ids)}"
+        if operation_ids
+        else "NULL::uuid[]"
+    )
+    return (
+        f"SELECT commit_cow_cleanup("
+        f"{_quote_literal(schema)}, "
+        f"{_quote_literal(base_table)}, "
+        f"{_to_uuid(session_id)}, "
+        f"{ops})"
+    )
+
+
+def get_cow_fk_edges_sql(schema: str, base_tables: list[str]) -> str:
+    """SQL to fetch FK edges among a set of base tables.
+
+    Returns rows of ``(parent_base_table, child_base_table, is_self_ref)``.
+    """
+    return (
+        f"SELECT parent_base_table, child_base_table, is_self_ref "
+        f"FROM _cow_fk_edges("
+        f"{_quote_literal(schema)}, {_to_text_array(base_tables)})"
+    )
+
+
+def alter_fk_constraints_deferrable_sql(
+    schema: str,
+    base_table: str,
+) -> str:
+    """SQL to flip all non-deferrable FK constraints on *base_table* to
+    ``DEFERRABLE INITIALLY IMMEDIATE``.
+
+    Runs a DO block that discovers the constraints and alters each one.
+    Idempotent: already-deferrable constraints are left alone.
+    """
+    return f"""
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT con.conname
+        FROM pg_constraint con
+        JOIN pg_class cls ON con.conrelid = cls.oid
+        JOIN pg_namespace ns ON cls.relnamespace = ns.oid
+        WHERE con.contype = 'f'
+          AND ns.nspname = {_quote_literal(schema)}
+          AND cls.relname = {_quote_literal(base_table)}
+          AND NOT con.condeferrable
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE {_quote_ident(schema)}.{_quote_ident(base_table)} ALTER CONSTRAINT %I DEFERRABLE INITIALLY IMMEDIATE',
+            r.conname
+        );
+    END LOOP;
+END
+$$;
+""".strip()
+
+
+def alter_fk_constraints_not_deferrable_sql(
+    schema: str,
+    base_table: str,
+) -> str:
+    """SQL to revert ``DEFERRABLE INITIALLY IMMEDIATE`` FKs on *base_table*
+    back to ``NOT DEFERRABLE``.
+
+    Only touches constraints currently marked ``DEFERRABLE INITIALLY IMMEDIATE``;
+    constraints that are ``INITIALLY DEFERRED`` (explicitly chosen by the
+    schema owner) are left alone.
+    """
+    return f"""
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT con.conname
+        FROM pg_constraint con
+        JOIN pg_class cls ON con.conrelid = cls.oid
+        JOIN pg_namespace ns ON cls.relnamespace = ns.oid
+        WHERE con.contype = 'f'
+          AND ns.nspname = {_quote_literal(schema)}
+          AND cls.relname = {_quote_literal(base_table)}
+          AND con.condeferrable
+          AND NOT con.condeferred
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE {_quote_ident(schema)}.{_quote_ident(base_table)} ALTER CONSTRAINT %I NOT DEFERRABLE',
+            r.conname
+        );
+    END LOOP;
+END
+$$;
+""".strip()
 
 
 def discard_cow_session_sql(

--- a/agentcow/postgres/tests/test_postgres.py
+++ b/agentcow/postgres/tests/test_postgres.py
@@ -588,52 +588,6 @@ async def test_enable_cow_makes_fk_constraints_deferrable(seeded_executor):
 
 
 @pytest.mark.asyncio
-async def test_disable_cow_reverts_fk_constraints_to_not_deferrable(seeded_executor):
-    """After disable_cow, FK constraints on the restored table should be
-    reverted back to NOT DEFERRABLE, undoing what enable_cow did."""
-    await deploy_cow_functions(seeded_executor)
-    await enable_cow(seeded_executor, "projects")
-    await disable_cow(seeded_executor, "projects")
-
-    rows = await seeded_executor.execute(
-        "SELECT con.conname, con.condeferrable "
-        "FROM pg_constraint con "
-        "JOIN pg_class cls ON con.conrelid = cls.oid "
-        "JOIN pg_namespace ns ON cls.relnamespace = ns.oid "
-        "WHERE con.contype = 'f' "
-        "  AND ns.nspname = 'public' "
-        "  AND cls.relname = 'projects'"
-    )
-    assert len(rows) > 0, "projects should have at least one FK constraint"
-    for conname, condeferrable in rows:
-        assert condeferrable is False, (
-            f"FK constraint {conname} on projects should no longer be deferrable"
-        )
-
-
-@pytest.mark.asyncio
-async def test_disable_cow_schema_reverts_fk_constraints(seeded_executor):
-    """disable_cow_schema should revert FK constraints on every restored table."""
-    await deploy_cow_functions(seeded_executor)
-    await enable_cow_schema(seeded_executor)
-    await disable_cow_schema(seeded_executor)
-
-    for table in ("tasks", "projects"):
-        rows = await seeded_executor.execute(
-            "SELECT con.conname, con.condeferrable "
-            "FROM pg_constraint con "
-            "JOIN pg_class cls ON con.conrelid = cls.oid "
-            "JOIN pg_namespace ns ON cls.relnamespace = ns.oid "
-            "WHERE con.contype = 'f' "
-            f"  AND ns.nspname = 'public' AND cls.relname = '{table}'"
-        )
-        for conname, condeferrable in rows:
-            assert condeferrable is False, (
-                f"FK constraint {conname} on {table} should no longer be deferrable"
-            )
-
-
-@pytest.mark.asyncio
 async def test_enable_cow_makes_multi_hop_fk_deferrable(seeded_executor):
     """tasks -> projects -> users: both levels of FK should become deferrable."""
     await deploy_cow_functions(seeded_executor)

--- a/agentcow/postgres/tests/test_postgres.py
+++ b/agentcow/postgres/tests/test_postgres.py
@@ -613,8 +613,54 @@ async def test_disable_cow_reverts_opted_in_fk_constraints(seeded_executor):
 
 
 @pytest.mark.asyncio
-async def test_disable_cow_schema_reverts_opted_in_fk_constraints(seeded_executor):
-    """disable_cow_schema reverts FK constraints on every opted-in table."""
+async def test_disable_cow_reverts_fk_constraints_to_not_deferrable(seeded_executor):
+    """After disable_cow, FK constraints on the restored table should be
+    reverted back to NOT DEFERRABLE, undoing what enable_cow did."""
+    await deploy_cow_functions(seeded_executor)
+    await enable_cow(seeded_executor, "projects")
+    await disable_cow(seeded_executor, "projects")
+
+    rows = await seeded_executor.execute(
+        "SELECT con.conname, con.condeferrable "
+        "FROM pg_constraint con "
+        "JOIN pg_class cls ON con.conrelid = cls.oid "
+        "JOIN pg_namespace ns ON cls.relnamespace = ns.oid "
+        "WHERE con.contype = 'f' "
+        "  AND ns.nspname = 'public' "
+        "  AND cls.relname = 'projects'"
+    )
+    assert len(rows) > 0, "projects should have at least one FK constraint"
+    for conname, condeferrable in rows:
+        assert (
+            condeferrable is False
+        ), f"FK constraint {conname} on projects should no longer be deferrable"
+
+
+@pytest.mark.asyncio
+async def test_disable_cow_schema_reverts_fk_constraints(seeded_executor):
+    """disable_cow_schema should revert FK constraints on every restored table."""
+    await deploy_cow_functions(seeded_executor)
+    await enable_cow_schema(seeded_executor)
+    await disable_cow_schema(seeded_executor)
+
+    for table in ("tasks", "projects"):
+        rows = await seeded_executor.execute(
+            "SELECT con.conname, con.condeferrable "
+            "FROM pg_constraint con "
+            "JOIN pg_class cls ON con.conrelid = cls.oid "
+            "JOIN pg_namespace ns ON cls.relnamespace = ns.oid "
+            "WHERE con.contype = 'f' "
+            f"  AND ns.nspname = 'public' AND cls.relname = '{table}'"
+        )
+        for conname, condeferrable in rows:
+            assert (
+                condeferrable is False
+            ), f"FK constraint {conname} on {table} should no longer be deferrable"
+
+
+@pytest.mark.asyncio
+async def test_enable_cow_makes_multi_hop_fk_deferrable(seeded_executor):
+    """tasks -> projects -> users: both levels of FK should become deferrable."""
     await deploy_cow_functions(seeded_executor)
     await enable_cow_schema(seeded_executor, allow_deferred_fks=True)
     await disable_cow_schema(seeded_executor)

--- a/agentcow/postgres/tests/test_postgres.py
+++ b/agentcow/postgres/tests/test_postgres.py
@@ -485,9 +485,7 @@ async def test_commit_schema_with_new_fk_referenced_rows(
     committed = await commit_cow_session_schema(seeded_executor, session_id)
     assert sorted(committed) == ["projects", "users"]
 
-    rows = await seeded_executor.execute(
-        "SELECT name FROM users WHERE id = 100"
-    )
+    rows = await seeded_executor.execute("SELECT name FROM users WHERE id = 100")
     assert rows == [("Petunia",)]
 
     rows = await seeded_executor.execute(
@@ -565,11 +563,38 @@ async def test_commit_single_table_with_fk_to_existing_row(
 
 
 @pytest.mark.asyncio
-async def test_enable_cow_makes_fk_constraints_deferrable(seeded_executor):
-    """After enable_cow, FK constraints on the base table should be marked
-    as DEFERRABLE so that SET CONSTRAINTS ALL DEFERRED can work."""
+async def test_enable_cow_with_allow_deferred_fks_opt_in(seeded_executor):
+    """When the caller opts in, FK constraints on the base table are
+    flipped to DEFERRABLE INITIALLY IMMEDIATE."""
     await deploy_cow_functions(seeded_executor)
-    await enable_cow(seeded_executor, "projects")
+    await enable_cow(seeded_executor, "projects", allow_deferred_fks=True)
+
+    rows = await seeded_executor.execute(
+        "SELECT con.conname, con.condeferrable, con.condeferred "
+        "FROM pg_constraint con "
+        "JOIN pg_class cls ON con.conrelid = cls.oid "
+        "JOIN pg_namespace ns ON cls.relnamespace = ns.oid "
+        "WHERE con.contype = 'f' "
+        "  AND ns.nspname = 'public' "
+        "  AND cls.relname = 'projects_base'"
+    )
+    assert len(rows) > 0
+    for conname, condeferrable, condeferred in rows:
+        assert (
+            condeferrable is True
+        ), f"FK {conname} on projects_base should be deferrable"
+        assert (
+            condeferred is False
+        ), f"FK {conname} on projects_base should be INITIALLY IMMEDIATE"
+
+
+@pytest.mark.asyncio
+async def test_disable_cow_reverts_opted_in_fk_constraints(seeded_executor):
+    """After an opt-in enable_cow(allow_deferred_fks=True), disable_cow
+    should flip the constraints back to NOT DEFERRABLE."""
+    await deploy_cow_functions(seeded_executor)
+    await enable_cow(seeded_executor, "projects", allow_deferred_fks=True)
+    await disable_cow(seeded_executor, "projects")
 
     rows = await seeded_executor.execute(
         "SELECT con.conname, con.condeferrable "
@@ -578,20 +603,43 @@ async def test_enable_cow_makes_fk_constraints_deferrable(seeded_executor):
         "JOIN pg_namespace ns ON cls.relnamespace = ns.oid "
         "WHERE con.contype = 'f' "
         "  AND ns.nspname = 'public' "
-        "  AND cls.relname = 'projects_base'"
+        "  AND cls.relname = 'projects'"
     )
-    assert len(rows) > 0, "projects_base should have at least one FK constraint"
+    assert len(rows) > 0
     for conname, condeferrable in rows:
-        assert condeferrable is True, (
-            f"FK constraint {conname} on projects_base should be deferrable"
-        )
+        assert (
+            condeferrable is False
+        ), f"FK constraint {conname} on projects should have been reverted"
 
 
 @pytest.mark.asyncio
-async def test_enable_cow_makes_multi_hop_fk_deferrable(seeded_executor):
-    """tasks -> projects -> users: both levels of FK should become deferrable."""
+async def test_disable_cow_schema_reverts_opted_in_fk_constraints(seeded_executor):
+    """disable_cow_schema reverts FK constraints on every opted-in table."""
     await deploy_cow_functions(seeded_executor)
-    await enable_cow_schema(seeded_executor)
+    await enable_cow_schema(seeded_executor, allow_deferred_fks=True)
+    await disable_cow_schema(seeded_executor)
+
+    for table in ("tasks", "projects"):
+        rows = await seeded_executor.execute(
+            "SELECT con.conname, con.condeferrable "
+            "FROM pg_constraint con "
+            "JOIN pg_class cls ON con.conrelid = cls.oid "
+            "JOIN pg_namespace ns ON cls.relnamespace = ns.oid "
+            "WHERE con.contype = 'f' "
+            f"  AND ns.nspname = 'public' AND cls.relname = '{table}'"
+        )
+        for conname, condeferrable in rows:
+            assert (
+                condeferrable is False
+            ), f"FK constraint {conname} on {table} should have been reverted"
+
+
+@pytest.mark.asyncio
+async def test_enable_cow_schema_opt_in_flips_multi_hop_fks(seeded_executor):
+    """tasks -> projects -> users: every FK across the chain is flipped
+    when allow_deferred_fks=True is used schema-wide."""
+    await deploy_cow_functions(seeded_executor)
+    await enable_cow_schema(seeded_executor, allow_deferred_fks=True)
 
     for base_table in ("tasks_base", "projects_base"):
         rows = await seeded_executor.execute(
@@ -603,17 +651,18 @@ async def test_enable_cow_makes_multi_hop_fk_deferrable(seeded_executor):
             f"  AND ns.nspname = 'public' AND cls.relname = '{base_table}'"
         )
         for conname, condeferrable in rows:
-            assert condeferrable is True, (
-                f"FK constraint {conname} on {base_table} should be deferrable"
-            )
+            assert (
+                condeferrable is True
+            ), f"FK {conname} on {base_table} should be deferrable"
 
 
 @pytest.mark.asyncio
 async def test_deferred_fk_constraints_context_manager(seeded_executor):
     """The deferred_fk_constraints context manager should defer and then
-    re-enable FK constraint checks."""
+    re-enable FK constraint checks. Requires FKs to be DEFERRABLE, so the
+    caller opts in with allow_deferred_fks=True."""
     await deploy_cow_functions(seeded_executor)
-    await enable_cow_schema(seeded_executor)
+    await enable_cow_schema(seeded_executor, allow_deferred_fks=True)
 
     async with deferred_fk_constraints(seeded_executor):
         await seeded_executor.execute(
@@ -629,9 +678,7 @@ async def test_deferred_fk_constraints_context_manager(seeded_executor):
         "SELECT title FROM projects_base WHERE id = 999"
     )
     assert rows == [("Phantom Project",)]
-    rows = await seeded_executor.execute(
-        "SELECT name FROM users_base WHERE id = 999"
-    )
+    rows = await seeded_executor.execute("SELECT name FROM users_base WHERE id = 999")
     assert rows == [("Ghost",)]
 
 
@@ -640,7 +687,8 @@ async def test_commit_schema_delete_and_reinsert_with_fk(
     seeded_executor, session_id, operation_id
 ):
     """Deleting a user and reinserting with the same ID, while a project
-    still references that user, should commit cleanly with deferral."""
+    still references that user, should commit cleanly via topological
+    ordering (upsert-before-delete within users_base)."""
     await deploy_cow_functions(seeded_executor)
     await enable_cow_schema(seeded_executor)
 
@@ -657,3 +705,108 @@ async def test_commit_schema_delete_and_reinsert_with_fk(
 
     rows = await seeded_executor.execute("SELECT name FROM users WHERE id = 1")
     assert rows == [("Bessie Jr",)]
+
+
+@pytest.mark.asyncio
+async def test_commit_schema_topological_ordering(
+    seeded_executor, session_id, operation_id
+):
+    """With the default non-intrusive path (no DEFERRABLE flip), a
+    schema-wide commit touching users -> projects -> tasks should
+    succeed via topological ordering alone."""
+    await deploy_cow_functions(seeded_executor)
+    await enable_cow_schema(seeded_executor)
+
+    for base_table in ("users_base", "projects_base", "tasks_base"):
+        rows = await seeded_executor.execute(
+            "SELECT condeferrable FROM pg_constraint con "
+            "JOIN pg_class cls ON con.conrelid = cls.oid "
+            "JOIN pg_namespace ns ON cls.relnamespace = ns.oid "
+            "WHERE con.contype = 'f' AND ns.nspname = 'public' "
+            f"AND cls.relname = '{base_table}'"
+        )
+        for (condeferrable,) in rows:
+            assert (
+                condeferrable is False
+            ), f"Default enable_cow_schema should NOT flip {base_table} FKs"
+
+    await apply_cow_variables(seeded_executor, session_id, operation_id)
+    await seeded_executor.execute(
+        "INSERT INTO users (id, name, email) "
+        "VALUES (500, 'Marigold', 'marigold@blossom.farm')"
+    )
+    await seeded_executor.execute(
+        "INSERT INTO projects (id, owner_id, title, description) "
+        "VALUES (500, 500, 'Blossom Orchard', 'Marigold hedges')"
+    )
+    await seeded_executor.execute(
+        "INSERT INTO tasks (project_id, assigned_to, title) "
+        "VALUES (500, 500, 'Plant marigolds')"
+    )
+    await reset_cow_variables(seeded_executor)
+
+    committed = await commit_cow_session_schema(seeded_executor, session_id)
+    assert committed == [
+        "users",
+        "projects",
+        "tasks",
+    ], "Parents should be committed before children"
+
+    rows = await seeded_executor.execute(
+        "SELECT title FROM tasks WHERE project_id = 500"
+    )
+    assert rows == [("Plant marigolds",)]
+
+
+@pytest.mark.asyncio
+async def test_commit_schema_delete_children_before_parents(
+    seeded_executor, session_id, operation_id
+):
+    """Deleting a project (child) and its owner (parent) in the same COW
+    session should commit cleanly — children are deleted before parents."""
+    await deploy_cow_functions(seeded_executor)
+    await enable_cow_schema(seeded_executor)
+
+    await apply_cow_variables(seeded_executor, session_id, operation_id)
+    await seeded_executor.execute("DELETE FROM tasks WHERE project_id = 1")
+    await seeded_executor.execute("DELETE FROM projects WHERE id = 1")
+    await seeded_executor.execute("DELETE FROM tasks WHERE assigned_to = 1")
+    await seeded_executor.execute("DELETE FROM users WHERE id = 1")
+    await reset_cow_variables(seeded_executor)
+
+    committed = await commit_cow_session_schema(seeded_executor, session_id)
+    assert sorted(committed) == ["projects", "tasks", "users"]
+
+    rows = await seeded_executor.execute("SELECT name FROM users WHERE id = 1")
+    assert rows == []
+    rows = await seeded_executor.execute("SELECT id FROM projects WHERE id = 1")
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_commit_schema_with_defer_fk_constraints_opt_in(
+    seeded_executor, session_id, operation_id
+):
+    """defer_fk_constraints=True reuses the deferred-check path, which
+    requires the caller to have enabled COW with allow_deferred_fks=True."""
+    await deploy_cow_functions(seeded_executor)
+    await enable_cow_schema(seeded_executor, allow_deferred_fks=True)
+
+    await apply_cow_variables(seeded_executor, session_id, operation_id)
+    await seeded_executor.execute(
+        "INSERT INTO users (id, name, email) "
+        "VALUES (600, 'Juniper', 'juniper@evergreen.farm')"
+    )
+    await seeded_executor.execute(
+        "INSERT INTO projects (id, owner_id, title, description) "
+        "VALUES (600, 600, 'Evergreen', 'Pine saplings')"
+    )
+    await reset_cow_variables(seeded_executor)
+
+    committed = await commit_cow_session_schema(
+        seeded_executor, session_id, defer_fk_constraints=True
+    )
+    assert sorted(committed) == ["projects", "users"]
+
+    rows = await seeded_executor.execute("SELECT name FROM users WHERE id = 600")
+    assert rows == [("Juniper",)]

--- a/agentcow/postgres/tests/test_postgres.py
+++ b/agentcow/postgres/tests/test_postgres.py
@@ -588,6 +588,52 @@ async def test_enable_cow_makes_fk_constraints_deferrable(seeded_executor):
 
 
 @pytest.mark.asyncio
+async def test_disable_cow_reverts_fk_constraints_to_not_deferrable(seeded_executor):
+    """After disable_cow, FK constraints on the restored table should be
+    reverted back to NOT DEFERRABLE, undoing what enable_cow did."""
+    await deploy_cow_functions(seeded_executor)
+    await enable_cow(seeded_executor, "projects")
+    await disable_cow(seeded_executor, "projects")
+
+    rows = await seeded_executor.execute(
+        "SELECT con.conname, con.condeferrable "
+        "FROM pg_constraint con "
+        "JOIN pg_class cls ON con.conrelid = cls.oid "
+        "JOIN pg_namespace ns ON cls.relnamespace = ns.oid "
+        "WHERE con.contype = 'f' "
+        "  AND ns.nspname = 'public' "
+        "  AND cls.relname = 'projects'"
+    )
+    assert len(rows) > 0, "projects should have at least one FK constraint"
+    for conname, condeferrable in rows:
+        assert condeferrable is False, (
+            f"FK constraint {conname} on projects should no longer be deferrable"
+        )
+
+
+@pytest.mark.asyncio
+async def test_disable_cow_schema_reverts_fk_constraints(seeded_executor):
+    """disable_cow_schema should revert FK constraints on every restored table."""
+    await deploy_cow_functions(seeded_executor)
+    await enable_cow_schema(seeded_executor)
+    await disable_cow_schema(seeded_executor)
+
+    for table in ("tasks", "projects"):
+        rows = await seeded_executor.execute(
+            "SELECT con.conname, con.condeferrable "
+            "FROM pg_constraint con "
+            "JOIN pg_class cls ON con.conrelid = cls.oid "
+            "JOIN pg_namespace ns ON cls.relnamespace = ns.oid "
+            "WHERE con.contype = 'f' "
+            f"  AND ns.nspname = 'public' AND cls.relname = '{table}'"
+        )
+        for conname, condeferrable in rows:
+            assert condeferrable is False, (
+                f"FK constraint {conname} on {table} should no longer be deferrable"
+            )
+
+
+@pytest.mark.asyncio
 async def test_enable_cow_makes_multi_hop_fk_deferrable(seeded_executor):
     """tasks -> projects -> users: both levels of FK should become deferrable."""
     await deploy_cow_functions(seeded_executor)


### PR DESCRIPTION
currently we defer foriegn key constraints during commits so that the operations can happen in any order without causing foreign key errors -- so we disable them at the start of the transaction and re-enable them at the end.

the problem is that this is intrusive, and ideally we donn't want to have to modify peoples' db schemas thisk way for cow to work. also, it shouldnt be necessary because postgres already allows multioperation commits that work for both delete/insert/etc -- so there should be a way to do this safely.

this change does operation-dependent commit ordering, so upserts happen parent-first and deletes happen child-first. this avoids foreign key violations in either case.

we still have the option to defer constraints when enabling cow, inc ase some schema has weird edge cases (eg. FK cycles) -- i would guess these are rare, but the option is htere in case people want it.

I also cleaned up the topo sort function so we didnt repeat it in so many places

Test Plan:
used it on my local cow deployment and did a couple multi-table commits to make sure it worked
